### PR TITLE
Refacto formulaire dans /auth

### DIFF
--- a/backend/src/resources/auth/auth.controller.ts
+++ b/backend/src/resources/auth/auth.controller.ts
@@ -6,13 +6,14 @@ import { UserService } from '@/resources/user/user.service';
 import { ResetPasswordDto } from '@/resources/auth/dto/resetPassword.dto';
 import { changePasswordDto } from '@/resources/auth/dto/changePassword.dto';
 import { Public } from '@/common/decorators/public.decorator';
+import verifyOTPDto from '@/resources/auth/dto/verifyOTPDto.dto';
 
 @Controller('auth')
 export class AuthController {
   constructor(
     private readonly authService: AuthService,
     private readonly userService: UserService,
-  ) {}
+  ) { }
 
   @Public()
   @Post('/login')
@@ -33,6 +34,15 @@ export class AuthController {
     @Body() changePassword: changePasswordDto,
   ) {
     return this.authService.forgotPassword(id, changePassword);
+  }
+
+  @Public()
+  @Post(':id/verify-otp')
+  verifyOTP(
+    @Param('id') id: string,
+    @Body() verifyOTP: verifyOTPDto,
+  ) {
+    return this.authService.verifyOTP(id, verifyOTP);
   }
 
   @Public()

--- a/backend/src/resources/auth/dto/verifyOTPDto.dto.ts
+++ b/backend/src/resources/auth/dto/verifyOTPDto.dto.ts
@@ -1,0 +1,3 @@
+export default interface verifyOTPDto {
+    otp: string
+}

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -420,6 +420,7 @@
     "toasts": {
       "sendingEmail": "An email has been sent! Check your spam folder.",
       "invalidEmail": "Invalid email",
+      "emailRequired": "The email is required",
       "emailNotFound": "No account found with this email",
       "internal": "An error occurred while trying to send the email"
     },

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -27,6 +27,7 @@
     },
     "errors": {
       "invalidEmail": "The email is invalid",
+      "passwordRequired": "The password is required",
       "invalidCredentials": "Email or password invalid",
       "internal": "An error occurred when we tried to log you in"
     },

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -456,6 +456,8 @@
     "toasts": {
       "passwordChanged": "Password changed!",
       "passwordsNotMatching": "Passwords do not match",
+      "passwordRequired": "You must enter a password",
+      "confirmPasswordRequired": "You must confirm your password",
       "internal": "An error occurred while trying to change the password"
     },
     "cancel": "Cancel"

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -26,6 +26,7 @@
       "link": "Enjoy free access !"
     },
     "errors": {
+      "emailRequired": "The email is required",
       "invalidEmail": "The email is invalid",
       "passwordRequired": "The password is required",
       "invalidCredentials": "Email or password invalid",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -438,7 +438,12 @@
     "label": "OTP",
     "placeholder": "Enter your code",
     "send": "Verify code",
-    "cancel": "Cancel"
+    "cancel": "Cancel",
+    "toasts": {
+      "invalidOTP": "The code is invalid",
+      "otpRequired": "You must enter the code sent by email",
+      "otpValid": "Code validated, you can change your password."
+    }
   },
   "changePassword": {
     "title": "Reset your password",
@@ -450,7 +455,6 @@
     "send": "Change password",
     "toasts": {
       "passwordChanged": "Password changed!",
-      "invalidOTP": "The code is invalid",
       "passwordsNotMatching": "Passwords do not match",
       "internal": "An error occurred while trying to change the password"
     },

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -419,6 +419,7 @@
     "toasts": {
       "sendingEmail": "¡Se ha enviado un correo! Revisa tu carpeta de spam.",
       "invalidEmail": "Correo electrónico inválido",
+      "emailRequired": "El correo electrónico es obligatorio",
       "emailNotFound": "No se encontró una cuenta con este correo",
       "internal": "Ocurrió un error al intentar enviar el correo"
     },

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -455,6 +455,8 @@
     "toasts": {
       "passwordChanged": "¡Contraseña cambiada!",
       "passwordsNotMatching": "Las contraseñas no coinciden",
+      "passwordRequired": "La contraseña es obligatoria",
+      "confirmPasswordRequired": "La confirmación de la contraseña es obligatoria",
       "internal": "Ocurrió un error al intentar cambiar la contraseña"
     },
     "cancel": "Cancelar"

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -27,6 +27,7 @@
     },
     "errors": {
       "invalidEmail": "El correo electrónico es inválido",
+      "passwordRequired": "La contraseña es obligatoria",
       "invalidCredentials": "Correo electrónico o contraseña inválidos",
       "internal": "Ocurrió un error al intentar iniciar sesión"
     },

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -26,6 +26,7 @@
       "link": "¡Disfruta del acceso gratuito !"
     },
     "errors": {
+      "emailRequired": "El correo electrónico es obligatorio",
       "invalidEmail": "El correo electrónico es inválido",
       "passwordRequired": "La contraseña es obligatoria",
       "invalidCredentials": "Correo electrónico o contraseña inválidos",

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -437,7 +437,12 @@
     "label": "OTP",
     "placeholder": "Ingresa tu código",
     "send": "Verificar código",
-    "cancel": "Cancelar"
+    "cancel": "Cancelar",
+    "toasts": {
+      "invalidOTP": "Código validado, puede cambiar su contraseña.",
+      "otpRequired": "Debe ingresar un código OTP válido",
+      "otpValid": "El código es válido."
+    }
   },
   "changePassword": {
     "title": "Restablecer tu contraseña",
@@ -449,7 +454,6 @@
     "send": "Cambiar contraseña",
     "toasts": {
       "passwordChanged": "¡Contraseña cambiada!",
-      "invalidOTP": "El código es inválido",
       "passwordsNotMatching": "Las contraseñas no coinciden",
       "internal": "Ocurrió un error al intentar cambiar la contraseña"
     },

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -420,6 +420,7 @@
     "toasts": {
       "sendingEmail": "Un email a été envoyé ! Vérifier vos spams.",
       "invalidEmail": "L'email est invalide",
+      "emailRequired": "L'email est requis",
       "emailNotFound": "Aucun compte trouvé avec cet email",
       "internal": "Une erreur c'est produite quand nous avons essayé de vous envoyer l'email"
     },

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -456,6 +456,8 @@
     "toasts": {
       "passwordChanged": "Mot de passe changé !",
       "passwordsNotMatching": "Les mots de passe ne correspondent pas",
+      "passwordRequired": "Le mot de passe est requis",
+      "confirmPasswordRequired": "La confirmation du mot de passe est requise",
       "internal": "Une erreur c'est produite quand nous avons essayé de changer le mot de passe"
     },
     "cancel": "Annuler"

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -26,6 +26,7 @@
       "link": "Profitez de l'accès gratuit !"
     },
     "errors": {
+      "emailRequired": "L'email est requis",
       "invalidEmail": "L'email est invalide",
       "passwordRequired": "Le mot de passe est requis",
       "invalidCredentials": "Email ou mot de passe invalide",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -438,7 +438,12 @@
     "label": "OPT",
     "placeholder": "Entrez votre code",
     "send": "Vérifier le code",
-    "cancel": "Annuler"
+    "cancel": "Annuler",
+    "toasts": {
+      "invalidOTP": "Le code est invalide",
+      "otpRequired": "Le code est requis",
+      "otpValid": "Code validé, vous pouvez changer votre mot de passe."
+    }
   },
   "changePassword": {
     "title": "Réinitialiser votre mot de passe",
@@ -450,7 +455,6 @@
     "send": "Changer le mot de passe",
     "toasts": {
       "passwordChanged": "Mot de passe changé !",
-      "invalidOTP": "Le code est invalide",
       "passwordsNotMatching": "Les mots de passe ne correspondent pas",
       "internal": "Une erreur c'est produite quand nous avons essayé de changer le mot de passe"
     },

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -27,6 +27,7 @@
     },
     "errors": {
       "invalidEmail": "L'email est invalide",
+      "passwordRequired": "Le mot de passe est requis",
       "invalidCredentials": "Email ou mot de passe invalide",
       "internal": "Une erreur c'est produite quand nous avons essayé de vous connecter"
     },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,10 +12,10 @@
         "@hookform/resolvers": "^5.0.1",
         "@radix-ui/react-avatar": "^1.1.4",
         "@radix-ui/react-checkbox": "^1.1.5",
-        "@radix-ui/react-label": "^2.1.4",
+        "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-popover": "^1.1.7",
         "@radix-ui/react-select": "^2.1.7",
-        "@radix-ui/react-slot": "^1.2.0",
+        "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-tabs": "^1.1.4",
         "@radix-ui/react-tooltip": "^1.2.4",
         "axios": "^1.8.1",
@@ -28,12 +28,12 @@
         "next-intl": "^3.26.5",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "react-hook-form": "^7.56.1",
+        "react-hook-form": "^7.57.0",
         "react-toastify": "^11.0.5",
         "tailwind-merge": "^3.0.1",
         "tailwindcss-animate": "^1.0.7",
         "toastr": "^2.1.4",
-        "zod": "^3.24.3"
+        "zod": "^3.25.51"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -6205,9 +6205,9 @@
       }
     },
     "node_modules/react-hook-form": {
-      "version": "7.56.4",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.56.4.tgz",
-      "integrity": "sha512-Rob7Ftz2vyZ/ZGsQZPaRdIefkgOSrQSPXfqBdvOPwJfoGnjwRJUs7EM7Kc1mcoDv3NOtqBzPGbcMB8CGn9CKgw==",
+      "version": "7.57.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.57.0.tgz",
+      "integrity": "sha512-RbEks3+cbvTP84l/VXGUZ+JMrKOS8ykQCRYdm5aYsxnDquL0vspsyNhGRO7pcH6hsZqWlPOjLye7rJqdtdAmlg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -7825,9 +7825,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.28",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.28.tgz",
-      "integrity": "sha512-/nt/67WYKnr5by3YS7LroZJbtcCBurDKKPBPWWzaxvVCGuG/NOsiKkrjoOhI8mJ+SQUXEbUzeB3S+6XDUEEj7Q==",
+      "version": "3.25.51",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.51.tgz",
+      "integrity": "sha512-TQSnBldh+XSGL+opiSIq0575wvDPqu09AqWe1F7JhUMKY+M91/aGlK4MhpVNO7MgYfHcVCB1ffwAUTJzllKJqg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,10 +17,10 @@
     "@hookform/resolvers": "^5.0.1",
     "@radix-ui/react-avatar": "^1.1.4",
     "@radix-ui/react-checkbox": "^1.1.5",
-    "@radix-ui/react-label": "^2.1.4",
+    "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-popover": "^1.1.7",
     "@radix-ui/react-select": "^2.1.7",
-    "@radix-ui/react-slot": "^1.2.0",
+    "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tabs": "^1.1.4",
     "@radix-ui/react-tooltip": "^1.2.4",
     "axios": "^1.8.1",
@@ -33,12 +33,12 @@
     "next-intl": "^3.26.5",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-hook-form": "^7.56.1",
+    "react-hook-form": "^7.57.0",
     "react-toastify": "^11.0.5",
     "tailwind-merge": "^3.0.1",
     "tailwindcss-animate": "^1.0.7",
     "toastr": "^2.1.4",
-    "zod": "^3.24.3"
+    "zod": "^3.25.51"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/frontend/src/app/[locale]/auth/forget-password/page.tsx
+++ b/frontend/src/app/[locale]/auth/forget-password/page.tsx
@@ -38,7 +38,6 @@ export default function ForgotPasswordPage() {
             setStep={setStep}
             setOTP={setOTP}
             userId={userId}
-            otp={otp}
           />
         )}
         {step === 3 && (

--- a/frontend/src/app/[locale]/auth/forget-password/page.tsx
+++ b/frontend/src/app/[locale]/auth/forget-password/page.tsx
@@ -37,6 +37,7 @@ export default function ForgotPasswordPage() {
           <ConfirmOTP
             setStep={setStep}
             setOTP={setOTP}
+            userId={userId}
             otp={otp}
           />
         )}

--- a/frontend/src/app/[locale]/auth/login/page.tsx
+++ b/frontend/src/app/[locale]/auth/login/page.tsx
@@ -15,7 +15,7 @@ import { z } from "zod";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Form, FormControl, FormField, FormItem, FormMessage } from "@/components/ui/form";
-import { EyeClosedIcon, EyeIcon, EyeOffIcon } from "lucide-react";
+import { EyeIcon, EyeOffIcon } from "lucide-react";
 
 export default function LoginPage() {
   const t = useTranslations("LoginPage");

--- a/frontend/src/app/[locale]/auth/login/page.tsx
+++ b/frontend/src/app/[locale]/auth/login/page.tsx
@@ -27,7 +27,7 @@ export default function LoginPage() {
   const { error, success } = useToast();
 
   const authFormSchema = z.object({
-    email: z.string().email(t("errors.invalidEmail")),
+    email: z.string().email(t("errors.emailRequired")),
     password: z.string().min(1, t("errors.passwordRequired")),
   });
 

--- a/frontend/src/app/[locale]/auth/login/page.tsx
+++ b/frontend/src/app/[locale]/auth/login/page.tsx
@@ -7,67 +7,59 @@ import { Input } from "@/components/ui/input";
 import { useToast } from "@/hooks/useToast";
 import authService from "@/services/authService";
 import Link from "next/link";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useState } from "react";
 import LocaleSwitcher from "@/components/locale/LocaleSwitcher";
 import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
+import { z } from "zod";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Form, FormControl, FormField, FormItem, FormMessage } from "@/components/ui/form";
+import { EyeClosedIcon, EyeIcon, EyeOffIcon } from "lucide-react";
 
 export default function LoginPage() {
   const t = useTranslations("LoginPage");
   const router = useRouter();
 
   const [loading, setLoading] = useState<boolean>(false);
-  const [email, setEmail] = useState<string>("");
-  const emailRef = useRef<string>("");
-  const [password, setPassword] = useState<string>("");
-  const passwordRef = useRef<string>("");
-
-  const updateEmail = (email: string) => {
-    emailRef.current = email;
-    setEmail(email);
-  };
-  const updatePassword = (password: string) => {
-    passwordRef.current = password;
-    setPassword(password);
-  };
-
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Enter") {
-        login();
-      }
-    };
-
-    window.addEventListener("keydown", handleKeyDown);
-    return () => {
-      window.removeEventListener("keydown", handleKeyDown);
-    };
-  }, []);
+  const [typePassword, setTypePassword] = useState<"password" | "string">("password");
 
   const { error, success } = useToast();
 
-  const login = useCallback(async () => {
+  const authFormSchema = z.object({
+    email: z.string().email(t("errors.invalidEmail")),
+    password: z.string().min(1, t("errors.passwordRequired")),
+  });
+
+  const form = useForm<z.infer<typeof authFormSchema>>({
+    resolver: zodResolver(authFormSchema),
+    defaultValues: {
+      email: "",
+      password: "",
+    },
+  });
+
+  const login = useCallback(async (values: z.infer<typeof authFormSchema>) => {
     if (loading) return;
     setLoading(true);
     try {
-      let emailRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
-      if (!emailRegex.test(emailRef.current)) {
-        error(t("errors.invalidEmail"));
-        return;
-      }
-
       const response = await authService.login({
-        email: emailRef.current,
-        password: passwordRef.current,
+        email: values.email,
+        password: values.password,
       });
       if (response.statusCode && response.statusCode !== 200) {
         error(t("errors.invalidCredentials"));
+        form.setError("email", {
+          message: t("errors.invalidCredentials"),
+        });
+        form.setError("password", {
+          message: t("errors.invalidCredentials"),
+        });
         return;
       } else {
         const secure = location.protocol === "https:" ? "Secure;" : "";
-        document.cookie = `accessToken=${response.access_token}; max-age=${
-          24 * 60 * 60
-        }; path=/; SameSite=Lax; ${secure}`;
+        document.cookie = `accessToken=${response.access_token}; max-age=${24 * 60 * 60
+          }; path=/; SameSite=Lax; ${secure}`;
 
         success(t("success.login"));
         router.push("/");
@@ -85,47 +77,89 @@ export default function LoginPage() {
         <LocaleSwitcher className="absolute right-0 border-none shadow-none m-1 bg-card" />
         <div className="p-6 w-full flex flex-col items-center justify-center gap-[5dvh]">
           <h1 className="text-xl font-bold">{t("title")}</h1>
-          <div className="w-full flex flex-col gap-[5dvh] items-center justify-center">
-            <div className="w-[50%] flex flex-col gap-4">
-              <Input
-                placeholder={t("email")}
-                type="email"
-                value={email}
-                onChange={(e) => updateEmail(e.target.value)}
-                className="bg-background"
-              />
-              <div className="flex flex-col gap-2">
-                <Input
-                  placeholder={t("password")}
-                  type="password"
-                  value={password}
-                  onChange={(e) => updatePassword(e.target.value)}
-                  className="bg-background"
+          <Form {...form}>
+            <form
+              onSubmit={form.handleSubmit(login)}
+              className="w-full flex flex-col gap-[5dvh] items-center justify-center">
+              <div className="w-[50%] flex flex-col gap-4">
+                <FormField
+                  control={form.control}
+                  name="email"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormControl>
+                        <Input
+                          placeholder={t("email")}
+                          {...field}
+                          className="bg-background"
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
                 />
-                <p className="text-[0.8rem] font-medium">
-                  <Link
-                    href="forget-password"
-                    className="hover:underline underline-offset-2">
-                    {t("forgotPassword")}
-                  </Link>
-                </p>
+
+                <div className="flex flex-col gap-2">
+                  <FormField
+                    control={form.control}
+                    name="password"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormControl>
+                          <div className="flex items-center justify-between relative">
+                            <Input
+                              placeholder={t("password")}
+                              {...field}
+                              type={typePassword}
+                              className="bg-background"
+                            />
+                            {
+                              typePassword === "password" ? (
+                                <EyeOffIcon
+                                  className="absolute right-2 cursor-pointer"
+                                  onClick={() => setTypePassword("string")}
+                                  size={20}
+                                />
+                              ) : (
+                                <EyeIcon
+                                  className="absolute right-2 cursor-pointer"
+                                  onClick={() => setTypePassword("password")}
+                                  size={20}
+                                />
+                              )
+                            }
+                          </div>
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <p className="text-[0.8rem] font-medium">
+                    <Link
+                      href="forget-password"
+                      className="hover:underline underline-offset-2">
+                      {t("forgotPassword")}
+                    </Link>
+                  </p>
+                </div>
               </div>
-            </div>
-            {!loading && (
-              <Button
-                className="w-[20%]"
-                onClick={() => login()}>
-                {t("login")}
-              </Button>
-            )}
-            {loading && (
-              <Button className="w-[20%]">
-                <Loading />
-              </Button>
-            )}
-          </div>
+              {!loading && (
+                <Button
+                  className="w-[20%]"
+                  type="submit">
+                  {t("login")}
+                </Button>
+              )}
+              {loading && (
+                <Button className="w-[20%]">
+                  <Loading />
+                </Button>
+              )}
+            </form>
+          </Form>
         </div>
-      </Card>
+      </Card >
       <div className="w-[40%] flex flex-col items-left">
         <p className="text-sm text-foreground">
           {t("noAccount.text")}{" "}
@@ -137,6 +171,6 @@ export default function LoginPage() {
           </Link>
         </p>
       </div>
-    </div>
+    </div >
   );
 }

--- a/frontend/src/components/modules/forgetPassword/changePassword.tsx
+++ b/frontend/src/components/modules/forgetPassword/changePassword.tsx
@@ -1,14 +1,19 @@
 "use client";
 
-import Field from "@/components/common/Field";
 import Loading from "@/components/common/Loading";
 import { Button } from "@/components/ui/button";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
 import { useToast } from "@/hooks/useToast";
 import AuthService from "@/services/authService";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { EyeIcon, EyeOffIcon } from "lucide-react";
 import { useTranslations } from "next-intl";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useCallback, useState } from "react";
+import { useForm } from "react-hook-form";
+import z from "zod";
 
 interface ChangePasswordProps {
   otp: string;
@@ -17,29 +22,49 @@ interface ChangePasswordProps {
 }
 export default function ChangePassword({ otp, userId, setStep }: ChangePasswordProps) {
   const t = useTranslations("changePassword");
+  const otpInlt = useTranslations("confirmOTP");
   const { success, error } = useToast();
   const router = useRouter();
 
-  const [password, setPassword] = useState<string>("");
-  const [confirmPassword, setConfirmPassword] = useState<string>("");
   const [loading, setLoading] = useState<boolean>(false);
+  const [typePassword, setTypePassword] = useState<"password" | "string">("password");
+  const [typeConfirmPassword, setTypeConfirmPassword] = useState<"password" | "string">("password");
 
-  const changePassword = useCallback(async (password: string, confirmPassword: string) => {
+  const changePasswordSchema = z.object({
+    password: z.string().min(1, t("toasts.passwordRequired")),
+    confirmPassword: z.string().min(1, t("toasts.confirmPasswordRequired")),
+  });
+
+  const form = useForm<z.infer<typeof changePasswordSchema>>({
+    resolver: zodResolver(changePasswordSchema),
+    defaultValues: {
+      password: "",
+      confirmPassword: "",
+    },
+  });
+
+  const changePassword = useCallback(async (values: z.infer<typeof changePasswordSchema>) => {
     try {
-      if (password !== confirmPassword) {
+      if (values.password !== values.confirmPassword) {
         error(t("toasts.passwordsNotMatching"));
+        form.setError("confirmPassword", {
+          message: t("toasts.passwordsNotMatching"),
+        });
         return;
       }
       setLoading(true);
-      let response = await AuthService.changePassword(userId, otp, password, confirmPassword);
+      let response = await AuthService.changePassword(userId, otp, values.password, values.confirmPassword);
       if (response.statusCode && response.statusCode === 401) {
-        error(t("toasts.invalidOTP"));
+        error(otpInlt("toasts.invalidOTP"));
         setStep(2);
         setLoading(false);
         return;
       }
       if (response.statusCode && response.statusCode === 400) {
         error(t("toasts.passwordsNotMatching"));
+        form.setError("confirmPassword", {
+          message: t("toasts.passwordsNotMatching"),
+        });
         setLoading(false);
         return;
       }
@@ -63,39 +88,98 @@ export default function ChangePassword({ otp, userId, setStep }: ChangePasswordP
         <h1 className="text-xl font-bold">{t("title")}</h1>
         <p className="text-sm w-[70%] text-center">{t("description")}</p>
       </div>
-      <div className="w-full flex flex-col gap-[4dvh] items-center justify-center">
-        <div className="w-[50%] flex flex-col gap-[2dvh]">
-          <Field
-            id={"password"}
-            type={"password"}
-            label={t("password")}
-            placeholder={t("placeholderPassword")}
-            value={password}
-            setValue={setPassword}
-          />
-          <Field
-            id={"confirmPassword"}
-            type={"password"}
-            label={t("confirmPassword")}
-            placeholder={t("placeholderConfirmPassword")}
-            value={confirmPassword}
-            setValue={setConfirmPassword}
-          />
-        </div>
-        <div className="w-[50%] flex flex-row gap-[2dvh] items-center justify-center">
-          <Link href={"login"}>
-            <Button variant={"outline"}>
-              {t("cancel")}
-            </Button>
-          </Link>
-          {!loading && <Button onClick={() => changePassword(password, confirmPassword)}>{t("send")}</Button>}
-          {loading && (
-            <Button className="w-[20%]">
-              <Loading />
-            </Button>
-          )}
-        </div>
-      </div>
+      <Form {...form}>
+        <form
+          onSubmit={form.handleSubmit(changePassword)}
+          className="w-full flex flex-col gap-[5dvh] items-center justify-center">
+          <div className="w-[50%] flex flex-col gap-[2dvh]">
+            <FormField
+              control={form.control}
+              name="password"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t("password")}</FormLabel>
+                  <FormControl>
+                    <div className="flex items-center justify-between relative">
+                      <Input
+                        placeholder={t("placeholderPassword")}
+                        {...field}
+                        type={typePassword}
+                        className="bg-background"
+                      />
+                      {
+                        typePassword === "password" ? (
+                          <EyeOffIcon
+                            className="absolute right-2 cursor-pointer"
+                            onClick={() => setTypePassword("string")}
+                            size={20}
+                          />
+                        ) : (
+                          <EyeIcon
+                            className="absolute right-2 cursor-pointer"
+                            onClick={() => setTypePassword("password")}
+                            size={20}
+                          />
+                        )
+                      }
+                    </div>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="confirmPassword"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t("confirmPassword")}</FormLabel>
+                  <FormControl>
+                    <div className="flex items-center justify-between relative">
+                      <Input
+                        placeholder={t("placeholderConfirmPassword")}
+                        {...field}
+                        type={typeConfirmPassword}
+                        className="bg-background"
+                      />
+                      {
+                        typeConfirmPassword === "password" ? (
+                          <EyeOffIcon
+                            className="absolute right-2 cursor-pointer"
+                            onClick={() => setTypeConfirmPassword("string")}
+                            size={20}
+                          />
+                        ) : (
+                          <EyeIcon
+                            className="absolute right-2 cursor-pointer"
+                            onClick={() => setTypeConfirmPassword("password")}
+                            size={20}
+                          />
+                        )
+                      }
+                    </div>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+          <div className="w-[50%] flex flex-row gap-[2dvh] items-center justify-center">
+            <Link href={"login"}>
+              <Button type="button" variant={"outline"}>
+                {t("cancel")}
+              </Button>
+            </Link>
+            {!loading && <Button type="submit">{t("send")}</Button>}
+            {loading && (
+              <Button className="w-[20%]">
+                <Loading />
+              </Button>
+            )}
+          </div>
+        </form>
+      </Form>
     </div>
   );
 }

--- a/frontend/src/components/modules/forgetPassword/confirmEmail.tsx
+++ b/frontend/src/components/modules/forgetPassword/confirmEmail.tsx
@@ -24,7 +24,7 @@ export default function ConfirmEmail({ setStep, setUserId }: ConfirmEmailProps) 
   const [loading, setLoading] = useState<boolean>(false);
 
   const confirmEmailSchema = z.object({
-    email: z.string().email(t("toasts.invalidEmail")),
+    email: z.string().email(t("toasts.emailRequired")),
   });
 
   const form = useForm<z.infer<typeof confirmEmailSchema>>({

--- a/frontend/src/components/modules/forgetPassword/confirmEmail.tsx
+++ b/frontend/src/components/modules/forgetPassword/confirmEmail.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import Field from "@/components/common/Field";
 import Loading from "@/components/common/Loading";
 import { Button } from "@/components/ui/button";
-import { Form, FormControl, FormField, FormItem, FormMessage } from "@/components/ui/form";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { useToast } from "@/hooks/useToast";
 import AuthService from "@/services/authService";
@@ -75,6 +74,7 @@ export default function ConfirmEmail({ setStep, setUserId }: ConfirmEmailProps) 
               name="email"
               render={({ field }) => (
                 <FormItem>
+                  <FormLabel>{t("label")}</FormLabel>
                   <FormControl>
                     <Input
                       placeholder={t("placeholder")}
@@ -89,7 +89,7 @@ export default function ConfirmEmail({ setStep, setUserId }: ConfirmEmailProps) 
           </div>
           <div className="w-[50%] flex flex-row gap-[2dvh] items-center justify-center">
             <Link href={"login"}>
-              <Button variant={"outline"}>
+              <Button type="button" variant={"outline"}>
                 {t("cancel")}
               </Button>
             </Link>

--- a/frontend/src/components/modules/forgetPassword/confirmEmail.tsx
+++ b/frontend/src/components/modules/forgetPassword/confirmEmail.tsx
@@ -41,14 +41,10 @@ export default function ConfirmEmail({ setStep, setUserId }: ConfirmEmailProps) 
       let locale = window.location.pathname.split("/")[1];
       let reponse = await AuthService.resetPassword(value.email, locale);
       if (reponse.statusCode && reponse.statusCode !== 200) {
-        error(t("toasts.emailNotFound"));
-        form.setError("email", {
-          message: t("toasts.emailNotFound"),
-        });
-        setLoading(false);
-        return;
+        setUserId(value.email);
+      } else {
+        setUserId(reponse.data._id);
       }
-      setUserId(reponse.data._id);
       success(t("toasts.sendingEmail"));
       setLoading(false);
       setStep(2);

--- a/frontend/src/components/modules/forgetPassword/confirmOTP.tsx
+++ b/frontend/src/components/modules/forgetPassword/confirmOTP.tsx
@@ -102,7 +102,17 @@ export default function ConfirmOTP({ setStep, setOTP, otp, userId }: ConfirmOTPP
                 {t("cancel")}
               </Button>
             </Link>
-            <Button type="submit">{t("send")}</Button>
+            {!loading && (
+              <Button
+                type="submit">
+                {t("send")}
+              </Button>
+            )}
+            {loading && (
+              <Button className="w-[20%]">
+                <Loading />
+              </Button>
+            )}
           </div>
         </form>
       </Form>

--- a/frontend/src/components/modules/forgetPassword/confirmOTP.tsx
+++ b/frontend/src/components/modules/forgetPassword/confirmOTP.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Field from "@/components/common/Field";
 import Loading from "@/components/common/Loading";
 import { Button } from "@/components/ui/button";
 import { Form, FormControl, FormField, FormItem, FormMessage } from "@/components/ui/form";

--- a/frontend/src/components/modules/forgetPassword/confirmOTP.tsx
+++ b/frontend/src/components/modules/forgetPassword/confirmOTP.tsx
@@ -3,18 +3,62 @@
 import Field from "@/components/common/Field";
 import Loading from "@/components/common/Loading";
 import { Button } from "@/components/ui/button";
+import { Form, FormControl, FormField, FormItem, FormMessage } from "@/components/ui/form";
 import { InputOTP, InputOTPGroup, InputOTPSeparator, InputOTPSlot } from "@/components/ui/input-otp";
+import { useToast } from "@/hooks/useToast";
+import AuthService from "@/services/authService";
+import { zodResolver } from "@hookform/resolvers/zod";
 import { useTranslations } from "next-intl";
 import Link from "next/link";
 import { useCallback, useState } from "react";
+import { useForm } from "react-hook-form";
+import z from "zod";
 
 interface ConfirmOTPProps {
   setStep: (step: 1 | 2 | 3) => void;
   setOTP: (otp: string) => void;
   otp: string;
+  userId: string;
 }
-export default function ConfirmOTP({ setStep, setOTP, otp }: ConfirmOTPProps) {
+export default function ConfirmOTP({ setStep, setOTP, otp, userId }: ConfirmOTPProps) {
   const t = useTranslations("confirmOTP");
+
+  const [loading, setLoading] = useState<boolean>(false);
+  const { success, error } = useToast();
+
+  const verifyOTPSchema = z.object({
+    otp: z.string().min(6, t("toasts.otpRequired")).max(6, t("toasts.otpRequired")),
+  });
+
+  const form = useForm<z.infer<typeof verifyOTPSchema>>({
+    resolver: zodResolver(verifyOTPSchema),
+    defaultValues: {
+      otp: ""
+    },
+  });
+
+  const verifyOTP = useCallback(async (value: z.infer<typeof verifyOTPSchema>) => {
+    try {
+
+      setLoading(true);
+      let reponse = await AuthService.verifyOTP(userId, value.otp);
+      if (reponse.statusCode && reponse.statusCode !== 200) {
+        error(t("toasts.invalidOTP"));
+        form.setError("otp", {
+          message: t("toasts.invalidOTP"),
+        });
+        setLoading(false);
+        return;
+      }
+      success(t("toasts.otpValid"));
+      setOTP(value.otp);
+      setLoading(false);
+      setStep(3);
+    } catch (e) {
+      console.log(e);
+      error(t("toasts.internal"));
+    }
+  }, []);
 
   return (
     <div className="p-6 w-full flex flex-col items-center justify-center gap-[4dvh]">
@@ -22,34 +66,46 @@ export default function ConfirmOTP({ setStep, setOTP, otp }: ConfirmOTPProps) {
         <h1 className="text-xl font-bold">{t("title")}</h1>
         <p className="text-sm w-[70%] text-center">{t("description")}</p>
       </div>
-      <div className="w-full flex flex-col gap-[4dvh] items-center justify-center">
-        <div className="w-[50%] justify-center flex flex-col items-center">
-          <InputOTP
-            maxLength={6}
-            value={otp}
-            onChange={(e) => setOTP(e)}>
-            <InputOTPGroup>
-              <InputOTPSlot index={0} />
-              <InputOTPSlot index={1} />
-              <InputOTPSlot index={2} />
-            </InputOTPGroup>
-            <InputOTPSeparator />
-            <InputOTPGroup>
-              <InputOTPSlot index={3} />
-              <InputOTPSlot index={4} />
-              <InputOTPSlot index={5} />
-            </InputOTPGroup>
-          </InputOTP>
-        </div>
-        <div className="w-[50%] flex flex-row gap-[2dvh] items-center justify-center">
-          <Link href={"login"}>
-            <Button variant={"outline"}>
-              {t("cancel")}
-            </Button>
-          </Link>
-          <Button onClick={() => setStep(3)}>{t("send")}</Button>
-        </div>
-      </div>
-    </div>
+      <Form {...form}>
+        <form
+          onSubmit={form.handleSubmit(verifyOTP)}
+          className="w-full flex flex-col gap-[5dvh] items-center justify-center">
+          <FormField
+            control={form.control}
+            name="otp"
+            render={({ field }) => (
+              <FormItem>
+                <FormControl>
+                  <InputOTP
+                    maxLength={6}
+                    {...field}>
+                    <InputOTPGroup>
+                      <InputOTPSlot index={0} />
+                      <InputOTPSlot index={1} />
+                      <InputOTPSlot index={2} />
+                    </InputOTPGroup>
+                    <InputOTPSeparator />
+                    <InputOTPGroup>
+                      <InputOTPSlot index={3} />
+                      <InputOTPSlot index={4} />
+                      <InputOTPSlot index={5} />
+                    </InputOTPGroup>
+                  </InputOTP>
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <div className="w-[50%] flex flex-row gap-[2dvh] items-center justify-center">
+            <Link href={"login"}>
+              <Button variant={"outline"}>
+                {t("cancel")}
+              </Button>
+            </Link>
+            <Button type="submit">{t("send")}</Button>
+          </div>
+        </form>
+      </Form>
+    </div >
   );
 }

--- a/frontend/src/components/modules/forgetPassword/confirmOTP.tsx
+++ b/frontend/src/components/modules/forgetPassword/confirmOTP.tsx
@@ -16,10 +16,9 @@ import z from "zod";
 interface ConfirmOTPProps {
   setStep: (step: 1 | 2 | 3) => void;
   setOTP: (otp: string) => void;
-  otp: string;
   userId: string;
 }
-export default function ConfirmOTP({ setStep, setOTP, otp, userId }: ConfirmOTPProps) {
+export default function ConfirmOTP({ setStep, setOTP, userId }: ConfirmOTPProps) {
   const t = useTranslations("confirmOTP");
 
   const [loading, setLoading] = useState<boolean>(false);
@@ -97,7 +96,7 @@ export default function ConfirmOTP({ setStep, setOTP, otp, userId }: ConfirmOTPP
           />
           <div className="w-[50%] flex flex-row gap-[2dvh] items-center justify-center">
             <Link href={"login"}>
-              <Button variant={"outline"}>
+              <Button type="button" variant={"outline"}>
                 {t("cancel")}
               </Button>
             </Link>

--- a/frontend/src/components/ui/form.tsx
+++ b/frontend/src/components/ui/form.tsx
@@ -76,7 +76,7 @@ const FormItem = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivEl
       <FormItemContext.Provider value={{ id }}>
         <div
           ref={ref}
-          className={cn("space-y-2", className)}
+          className={cn("", className)}
           {...props}
         />
       </FormItemContext.Provider>

--- a/frontend/src/providers/authProvider.tsx
+++ b/frontend/src/providers/authProvider.tsx
@@ -35,13 +35,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     setIsLoading(false);
   }, [pathname, router, locale]);
 
-  if (isLoading) {
-    return (
-      <div className="flex items-center justify-center h-screen">
-        <div className="loader"></div>
-      </div>
-    );
-  }
   return <AuthContext.Provider value={{ isLoading }}>{children}</AuthContext.Provider>;
 }
 

--- a/frontend/src/services/apiConfig.ts
+++ b/frontend/src/services/apiConfig.ts
@@ -11,14 +11,13 @@ const apiClient = (contentType: string) => {
     baseURL: url,
     headers: {
       "Content-Type": contentType || APIContentType.JSON,
-      Authorization: `Bearer ${
-        typeof window !== "undefined"
-          ? document.cookie
-              .split("; ")
-              .find((row) => row.startsWith("accessToken="))
-              ?.split("=")[1] || ""
-          : ""
-      }`,
+      Authorization: `Bearer ${typeof window !== "undefined"
+        ? document.cookie
+          .split("; ")
+          .find((row) => row.startsWith("accessToken="))
+          ?.split("=")[1] || ""
+        : ""
+        }`,
     },
     withCredentials: true,
   });
@@ -26,11 +25,14 @@ const apiClient = (contentType: string) => {
   instance.interceptors.response.use(
     (response) => response,
     (error) => {
+      console.error("API Error:", error);
       if (error.response?.status === 401) {
-        document.cookie = "accessToken=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;";
+        if (!error.response.request.responseURL.includes("/auth/")) {
+          document.cookie = "accessToken=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;";
 
-        if (typeof window !== "undefined") {
-          window.location.href = "/auth/login";
+          if (typeof window !== "undefined") {
+            window.location.href = "/auth/login";
+          }
         }
       }
 

--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -70,6 +70,21 @@ const AuthService = {
       return err.response?.data;
     }
   },
+
+  async verifyOTP(id: string, otp: string) {
+    try {
+      const response = await apiClient(APIContentType.JSON).post(`/auth/${id}/verify-otp`, { otp });
+
+      if (!response || !response.data || response === undefined) {
+        throw new Error("Invalid API response");
+      }
+
+      return response.data;
+    } catch (err: any) {
+      console.error("API error:", err);
+      return err.response?.data;
+    }
+  },
 };
 
 export default AuthService;


### PR DESCRIPTION
## Description
Correctifs de bugs d'affichage du toast de connexion et refonte de gestion d'erreurs des formulaires

## Problème résolu
 - [x] Ajout d'une route de vérification de l'OTP (à l'étape 2 du changement de mdp, le back vérify l'OTP avant de passer à l'étape 3)
 - [x] Correctif du toast de connexion réussi
 - [x] Refonte du système de formulaire de login
 - [x] Refonte du système des formulaires du système de changement de mdp
 - [x] Ajout d'un toggle pour afficher ou non d'un mdp (page login et changement de mdp)

## Liste de contrôle
 - [x] J'ai testé mes changements localement
 - [x] J'ai ajouté/mis à jour la documentation (si nécessaire)
 - [x] J'ai ajouté des tests pour couvrir mes changements
 - [x] Tous les tests existants passent
 - [x] Mon code suit les conventions de style du projet

## Notes pour le reviewer (Jovis)
 - [x] La branche d'origin et la branche de destination sont correctes
 - [x] Les changements ont été résolu et des remarques ont été ajouté (si nécessaire)
 - [x] Les changements ont été testé
 
## Notes pour le reviewer (Elvis)
 - [x] La branche d'origin et la branche de destination sont correctes
 - [x] Les changements ont été résolu et des remarques ont été ajouté (si nécessaire)
 - [x] Les changements ont été testé