### PR TITLE
Changement de langue dans reset password

### DIFF
--- a/frontend/src/app/[locale]/auth/forget-password/page.tsx
+++ b/frontend/src/app/[locale]/auth/forget-password/page.tsx
@@ -16,9 +16,18 @@ export default function ForgotPasswordPage() {
   const [otp, setOTP] = useState<string>("");
   const [userId, setUserId] = useState<string>("");
 
+  const [isMounted, setIsMounter] = useState<boolean>(false);
+
+  const cancel = () => {
+    document.cookie = `step=; otp=; userId=;`;
+  }
+
   useEffect(() => {
-    document.cookie = `step=${step}; otp=${otp}; userId=${userId};`;
-    console.log(`Cookie set: step=${step}, otp=${otp}, userId=${userId}`);
+    if (isMounted) {
+      document.cookie = `step=${step};`;
+      document.cookie = `otp=${otp};`;
+      document.cookie = `userId=${userId};`;
+    }
   }, [step, otp, userId]);
 
   useEffect(() => {
@@ -38,8 +47,6 @@ export default function ForgotPasswordPage() {
       .find((row) => row.startsWith("userId="))
       ?.split("=")[1];
 
-    console.log(stepParam, otpParam, userIdParam);
-
     if (stepParam) {
       setStep(Number(stepParam) as 1 | 2 | 3);
     }
@@ -49,6 +56,8 @@ export default function ForgotPasswordPage() {
     if (userIdParam) {
       setUserId(userIdParam);
     }
+
+    setIsMounter(true);
   }, []);
 
   return (
@@ -65,6 +74,7 @@ export default function ForgotPasswordPage() {
           <ConfirmEmail
             setStep={setStep}
             setUserId={setUserId}
+            cancel={cancel}
           />
         )}
         {step === 2 && (
@@ -72,6 +82,7 @@ export default function ForgotPasswordPage() {
             setStep={setStep}
             setOTP={setOTP}
             userId={userId}
+            cancel={cancel}
           />
         )}
         {step === 3 && (
@@ -79,6 +90,7 @@ export default function ForgotPasswordPage() {
             otp={otp}
             userId={userId}
             setStep={setStep}
+            cancel={cancel}
           />
         )}
       </Card>

--- a/frontend/src/app/[locale]/auth/forget-password/page.tsx
+++ b/frontend/src/app/[locale]/auth/forget-password/page.tsx
@@ -7,15 +7,49 @@ import ConfirmOTP from "@/components/modules/forgetPassword/confirmOTP";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { useTranslations } from "next-intl";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 export default function ForgotPasswordPage() {
   const t = useTranslations("forgetPassword");
 
   const [step, setStep] = useState<1 | 2 | 3>(1);
-
   const [otp, setOTP] = useState<string>("");
   const [userId, setUserId] = useState<string>("");
+
+  useEffect(() => {
+    document.cookie = `step=${step}; otp=${otp}; userId=${userId};`;
+    console.log(`Cookie set: step=${step}, otp=${otp}, userId=${userId}`);
+  }, [step, otp, userId]);
+
+  useEffect(() => {
+
+    const stepParam: string | undefined = document.cookie
+      .split("; ")
+      .find((row) => row.startsWith("step="))
+      ?.split("=")[1];
+
+    const otpParam: string | undefined = document.cookie
+      .split("; ")
+      .find((row) => row.startsWith("otp="))
+      ?.split("=")[1];
+
+    const userIdParam: string | undefined = document.cookie
+      .split("; ")
+      .find((row) => row.startsWith("userId="))
+      ?.split("=")[1];
+
+    console.log(stepParam, otpParam, userIdParam);
+
+    if (stepParam) {
+      setStep(Number(stepParam) as 1 | 2 | 3);
+    }
+    if (otpParam) {
+      setOTP(otpParam);
+    }
+    if (userIdParam) {
+      setUserId(userIdParam);
+    }
+  }, []);
 
   return (
     <div className="w-full h-[100dvh] gap-1 flex flex-col items-center bg-background">

--- a/frontend/src/components/modules/forgetPassword/changePassword.tsx
+++ b/frontend/src/components/modules/forgetPassword/changePassword.tsx
@@ -19,8 +19,9 @@ interface ChangePasswordProps {
   otp: string;
   userId: string;
   setStep: (step: 1 | 2 | 3) => void;
+  cancel: () => void;
 }
-export default function ChangePassword({ otp, userId, setStep }: ChangePasswordProps) {
+export default function ChangePassword({ otp, userId, setStep, cancel }: ChangePasswordProps) {
   const t = useTranslations("changePassword");
   const otpInlt = useTranslations("confirmOTP");
   const { success, error } = useToast();
@@ -167,7 +168,7 @@ export default function ChangePassword({ otp, userId, setStep }: ChangePasswordP
           </div>
           <div className="w-[50%] flex flex-row gap-[2dvh] items-center justify-center">
             <Link href={"login"}>
-              <Button type="button" variant={"outline"}>
+              <Button type="button" onClick={cancel} variant={"outline"}>
                 {t("cancel")}
               </Button>
             </Link>

--- a/frontend/src/components/modules/forgetPassword/confirmEmail.tsx
+++ b/frontend/src/components/modules/forgetPassword/confirmEmail.tsx
@@ -49,8 +49,8 @@ export default function ConfirmEmail({ setStep, setUserId }: ConfirmEmailProps) 
       setLoading(false);
       setStep(2);
     } catch (e) {
-      console.log(e);
       error(t("toasts.internal"));
+      setLoading(false);
     }
   }, []);
 

--- a/frontend/src/components/modules/forgetPassword/confirmEmail.tsx
+++ b/frontend/src/components/modules/forgetPassword/confirmEmail.tsx
@@ -16,8 +16,9 @@ import z from "zod";
 interface ConfirmEmailProps {
   setStep: (step: 1 | 2 | 3) => void;
   setUserId: (userId: string) => void;
+  cancel: () => void
 }
-export default function ConfirmEmail({ setStep, setUserId }: ConfirmEmailProps) {
+export default function ConfirmEmail({ setStep, setUserId, cancel }: ConfirmEmailProps) {
   const t = useTranslations("confirmEmail");
   const { success, error } = useToast();
 
@@ -85,7 +86,7 @@ export default function ConfirmEmail({ setStep, setUserId }: ConfirmEmailProps) 
           </div>
           <div className="w-[50%] flex flex-row gap-[2dvh] items-center justify-center">
             <Link href={"login"}>
-              <Button type="button" variant={"outline"}>
+              <Button type="button" onClick={cancel} variant={"outline"}>
                 {t("cancel")}
               </Button>
             </Link>

--- a/frontend/src/components/modules/forgetPassword/confirmOTP.tsx
+++ b/frontend/src/components/modules/forgetPassword/confirmOTP.tsx
@@ -17,8 +17,9 @@ interface ConfirmOTPProps {
   setStep: (step: 1 | 2 | 3) => void;
   setOTP: (otp: string) => void;
   userId: string;
+  cancel: () => void;
 }
-export default function ConfirmOTP({ setStep, setOTP, userId }: ConfirmOTPProps) {
+export default function ConfirmOTP({ setStep, setOTP, userId, cancel }: ConfirmOTPProps) {
   const t = useTranslations("confirmOTP");
 
   const [loading, setLoading] = useState<boolean>(false);
@@ -96,7 +97,7 @@ export default function ConfirmOTP({ setStep, setOTP, userId }: ConfirmOTPProps)
           />
           <div className="w-[50%] flex flex-row gap-[2dvh] items-center justify-center">
             <Link href={"login"}>
-              <Button type="button" variant={"outline"}>
+              <Button type="button" onClick={cancel} variant={"outline"}>
                 {t("cancel")}
               </Button>
             </Link>


### PR DESCRIPTION
## Description
Eviter de revenir au début du formulaire de changement de mot de passe quand on change de langue

## Liste de contrôle
 - [x] J'ai testé mes changements localement
 - [x] Mon code suit les conventions de style du projet

## Notes pour le reviewer
 - [x] La branche d'origin et la branche de destination sont correctes
 - [x] Les changements ont été résolu et des remarques ont été ajouté (si nécessaire)
 - [x] Les changements ont été testé