### PR TITLE
Bloquer les push sur main

### DIFF
--- a/.github/workflows/pr-to-main.yml
+++ b/.github/workflows/pr-to-main.yml
@@ -1,0 +1,13 @@
+name: PR to main branch only from integ
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  call-blocker:
+    uses: ./.github/workflows/block-non-authorized-branches.yml
+    with:
+      source_branch: integ
+      target_branch: main


### PR DESCRIPTION
## Description
 - Impossible de push dans main sans PR
 - Impossible de faire des PR sur main depuis autre chose qu'integ
 
## Problème résolu
`main` est sécurisé

## Liste de contrôle
 - [x] J'ai testé mes changements localement
 - [x] J'ai ajouté/mis à jour la documentation (si nécessaire)
 - [x] Mon code suit les conventions de style du projet

## Notes pour le reviewer
 - [ ] La branche d'origin et la branche de destination sont correctes
 - [ ] Les changements ont été résolu et des remarques ont été ajouté (si nécessaire)
 - [ ] Les changements ont été testé