### PR TITLE
542 chariot fix vulnérabilités docker

### DIFF
--- a/.github/workflows/sast-scan.yml
+++ b/.github/workflows/sast-scan.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: SonarCloud Scan (Monorepo)
         if: steps.check-sonar.outputs.present == 'true'
-        uses: SonarSource/sonarqube-scan-action@v5.3.2
+        uses: SonarSource/sonarqube-scan-action@v6
         continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/security-report.yml
+++ b/.github/workflows/security-report.yml
@@ -160,7 +160,7 @@ jobs:
           EOF
           fi
 
-          echo "## 📝 Détail des vulnérabilités CRITIQUES détectées" >> security/reports/summary.md
+          echo "## 📝 Détail des vulnérabilités détectées" >> security/reports/summary.md
           echo "" >> security/reports/summary.md
 
           FOUND_CRITICAL="false"

--- a/backend/dockerfile
+++ b/backend/dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:20.18-alpine
 
 WORKDIR /app
 

--- a/backend/dockerfile
+++ b/backend/dockerfile
@@ -1,4 +1,16 @@
-FROM node:25
+
+FROM debian:12.12-slim
+
+RUN apt-get update && \
+    apt-get install -y curl gnupg ca-certificates && \
+    mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_25.x nodistro main" > /etc/apt/sources.list.d/nodesource.list && \
+    apt-get update && \
+    apt-get install -y nodejs git imagemagick libaom3 && \
+    apt-get upgrade -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 

--- a/backend/dockerfile
+++ b/backend/dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.18-alpine
+FROM node:25-alpine
 
 WORKDIR /app
 

--- a/backend/dockerfile
+++ b/backend/dockerfile
@@ -1,5 +1,4 @@
-
-FROM debian:12.12-slim
+FROM debian:trixie-slim
 
 RUN apt-get update && \
     apt-get install -y curl gnupg ca-certificates && \
@@ -9,8 +8,7 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y nodejs git imagemagick libaom3 && \
     apt-get upgrade -y && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 

--- a/backend/dockerfile
+++ b/backend/dockerfile
@@ -1,14 +1,4 @@
-FROM debian:trixie-slim
-
-RUN apt-get update && \
-    apt-get install -y curl gnupg ca-certificates && \
-    mkdir -p /etc/apt/keyrings && \
-    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
-    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_25.x nodistro main" > /etc/apt/sources.list.d/nodesource.list && \
-    apt-get update && \
-    apt-get install -y nodejs git imagemagick libaom3 && \
-    apt-get upgrade -y && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+FROM node:20-alpine
 
 WORKDIR /app
 

--- a/frontend/dockerfile
+++ b/frontend/dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:20.18-alpine
 
 WORKDIR /app
 

--- a/frontend/dockerfile
+++ b/frontend/dockerfile
@@ -1,4 +1,4 @@
-FROM debian:12.12-slim
+FROM debian:trixie-slim
 
 RUN apt-get update && \
     apt-get install -y curl gnupg ca-certificates && \
@@ -8,9 +8,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y nodejs git imagemagick libaom3 && \
     apt-get upgrade -y && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-    
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 COPY . .

--- a/frontend/dockerfile
+++ b/frontend/dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.18-alpine
+FROM node:25-alpine
 
 WORKDIR /app
 

--- a/frontend/dockerfile
+++ b/frontend/dockerfile
@@ -1,14 +1,4 @@
-FROM debian:trixie-slim
-
-RUN apt-get update && \
-    apt-get install -y curl gnupg ca-certificates && \
-    mkdir -p /etc/apt/keyrings && \
-    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
-    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_25.x nodistro main" > /etc/apt/sources.list.d/nodesource.list && \
-    apt-get update && \
-    apt-get install -y nodejs git imagemagick libaom3 && \
-    apt-get upgrade -y && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+FROM node:20-alpine
 
 WORKDIR /app
 

--- a/frontend/dockerfile
+++ b/frontend/dockerfile
@@ -1,5 +1,16 @@
-FROM node:25
+FROM debian:12.12-slim
 
+RUN apt-get update && \
+    apt-get install -y curl gnupg ca-certificates && \
+    mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_25.x nodistro main" > /etc/apt/sources.list.d/nodesource.list && \
+    apt-get update && \
+    apt-get install -y nodejs git imagemagick libaom3 && \
+    apt-get upgrade -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+    
 WORKDIR /app
 
 COPY . .


### PR DESCRIPTION
## 🔗 Lien vers le ticket
#542 

## 🧑‍💻 Contrôles pour le développeur
- [x] J'ai testé mes changements localement  

## 🔍 Contrôles pour le reviewer
- [x] La branche d’origine et la branche de destination sont correctes  
- [x] Les changements ont été résolus et les remarques ajoutées (si nécessaire)  
- [x] Les changements ont été testés  

## 📝 Notes pour le reviewer
- Je sais pas pourquoi, mais le docker de dev était en node 20 mais la prod en node 25
- Donc point positive: 
   - en prod on à jamais eu de vulnérabilités
   - on a plus de vulnérabilité en dev